### PR TITLE
Add simple PHP note-taking app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Noted
-An online note taking app
+
+Simple note taking app built with PHP and SQLite.
+
+## Usage
+
+1. Start the PHP built-in server:
+   ```
+   php -S localhost:8000
+   ```
+2. Open `http://localhost:8000/index.php` in your browser.
+
+The app allows you to create, view, edit, and delete notes. Each note has a title and description. Creation and update times are recorded using the user's local datetime via JavaScript. The interface uses plain HTML with no styling.

--- a/create.php
+++ b/create.php
@@ -1,0 +1,40 @@
+<?php
+require 'db.php';
+$db = get_db();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = $_POST['title'] ?? '';
+    $description = $_POST['description'] ?? '';
+    $datetime = $_POST['current_datetime'] ?? '';
+    if ($title !== '' && $description !== '' && $datetime !== '') {
+        $stmt = $db->prepare('INSERT INTO notes (title, description, created_at, updated_at) VALUES (?, ?, ?, ?)');
+        $stmt->execute([$title, $description, $datetime, $datetime]);
+        header('Location: index.php');
+        exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Create Note</title>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.getElementById('current_datetime').value = new Date().toISOString();
+    });
+    </script>
+</head>
+<body>
+    <h1>Create Note</h1>
+    <form method="post">
+        <label>Title</label>
+        <input type="text" name="title" required>
+        <br>
+        <label>Description</label>
+        <textarea name="description" required></textarea>
+        <input type="hidden" name="current_datetime" id="current_datetime">
+        <br>
+        <button type="submit">Save</button>
+    </form>
+    <a href="index.php">Back</a>
+</body>
+</html>

--- a/db.php
+++ b/db.php
@@ -1,0 +1,14 @@
+<?php
+function get_db() {
+    $db = new PDO('sqlite:' . __DIR__ . '/notes.db');
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $db->exec('CREATE TABLE IF NOT EXISTS notes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )');
+    return $db;
+}
+?>

--- a/edit.php
+++ b/edit.php
@@ -1,0 +1,63 @@
+<?php
+require 'db.php';
+$db = get_db();
+$id = $_GET['id'] ?? null;
+if (!$id) {
+    header('Location: index.php');
+    exit;
+}
+$stmt = $db->prepare('SELECT * FROM notes WHERE id = ?');
+$stmt->execute([$id]);
+$note = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$note) {
+    header('Location: index.php');
+    exit;
+}
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['delete'])) {
+        $db->prepare('DELETE FROM notes WHERE id = ?')->execute([$id]);
+        header('Location: index.php');
+        exit;
+    } else {
+        $title = $_POST['title'] ?? '';
+        $description = $_POST['description'] ?? '';
+        $datetime = $_POST['current_datetime'] ?? '';
+        if ($title !== '' && $description !== '' && $datetime !== '') {
+            $stmt = $db->prepare('UPDATE notes SET title = ?, description = ?, updated_at = ? WHERE id = ?');
+            $stmt->execute([$title, $description, $datetime, $id]);
+            header('Location: index.php');
+            exit;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Edit Note</title>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.getElementById('current_datetime').value = new Date().toISOString();
+    });
+    </script>
+</head>
+<body>
+    <h1>Edit Note</h1>
+    <p>Created: <?php echo $note['created_at']; ?></p>
+    <form method="post">
+        <label>Title</label>
+        <input type="text" name="title" value="<?php echo htmlspecialchars($note['title']); ?>" required>
+        <br>
+        <label>Description</label>
+        <textarea name="description" required><?php echo htmlspecialchars($note['description']); ?></textarea>
+        <input type="hidden" name="current_datetime" id="current_datetime">
+        <br>
+        <button type="submit">Update</button>
+    </form>
+    <form method="post" onsubmit="return confirm('Delete this note?');">
+        <input type="hidden" name="delete" value="1">
+        <button type="submit">Delete</button>
+    </form>
+    <a href="index.php">Back</a>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,23 @@
+<?php
+require 'db.php';
+$db = get_db();
+$notes = $db->query('SELECT id, title, created_at, updated_at FROM notes ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Noted</title>
+</head>
+<body>
+    <h1>Noted</h1>
+    <a href="create.php">Create Note</a>
+    <ul>
+    <?php foreach ($notes as $note): ?>
+        <li>
+            <a href="edit.php?id=<?php echo $note['id']; ?>"><?php echo htmlspecialchars($note['title']); ?></a>
+            (created: <?php echo $note['created_at']; ?>, updated: <?php echo $note['updated_at']; ?>)
+        </li>
+    <?php endforeach; ?>
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implement a basic SQLite-backed note system with PHP
- Provide pages for listing, creating, editing, and deleting notes
- Record creation and update timestamps using the user's local time

## Testing
- `php -l db.php`
- `php -l index.php`
- `php -l create.php`
- `php -l edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad8e4ad63083268e456a5f886bb4df