### PR TITLE
Refine note pages with cleaner markup

### DIFF
--- a/create.php
+++ b/create.php
@@ -4,37 +4,40 @@ $db = get_db();
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = $_POST['title'] ?? '';
     $description = $_POST['description'] ?? '';
-    $datetime = $_POST['current_datetime'] ?? '';
-    if ($title !== '' && $description !== '' && $datetime !== '') {
+    if ($title !== '' && $description !== '') {
+        $now = date('c');
         $stmt = $db->prepare('INSERT INTO notes (title, description, created_at, updated_at) VALUES (?, ?, ?, ?)');
-        $stmt->execute([$title, $description, $datetime, $datetime]);
+        $stmt->execute([$title, $description, $now, $now]);
         header('Location: index.php');
         exit;
     }
 }
 ?>
-<!DOCTYPE html>
-<html>
-<head>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
     <title>Create Note</title>
-    <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        document.getElementById('current_datetime').value = new Date().toISOString();
-    });
-    </script>
-</head>
-<body>
+  </head>
+  <body>
     <h1>Create Note</h1>
-    <form method="post">
-        <label>Title</label>
-        <input type="text" name="title" required>
-        <br>
-        <label>Description</label>
-        <textarea name="description" required></textarea>
-        <input type="hidden" name="current_datetime" id="current_datetime">
-        <br>
+
+    <form method="post" action="/create.php">
+      <p>
+        <label for="title"><strong>Title:</strong></label><br>
+        <input id="title" name="title" type="text" size="40" required>
+      </p>
+
+      <p>
+        <label for="description"><strong>Description:</strong></label><br>
+        <textarea id="description" name="description" rows="6" cols="60" required></textarea>
+      </p>
+
+      <p>
         <button type="submit">Save</button>
+      </p>
     </form>
-    <a href="index.php">Back</a>
-</body>
+
+    <p><a href="/index.php">Back</a></p>
+  </body>
 </html>

--- a/edit.php
+++ b/edit.php
@@ -1,7 +1,7 @@
 <?php
 require 'db.php';
 $db = get_db();
-$id = $_GET['id'] ?? null;
+$id = (int)($_GET['id'] ?? 0);
 if (!$id) {
     header('Location: index.php');
     exit;
@@ -14,50 +14,55 @@ if (!$note) {
     exit;
 }
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (isset($_POST['delete'])) {
+    $action = $_POST['action'] ?? '';
+    if ($action === 'delete') {
         $db->prepare('DELETE FROM notes WHERE id = ?')->execute([$id]);
         header('Location: index.php');
         exit;
-    } else {
+    } elseif ($action === 'update') {
         $title = $_POST['title'] ?? '';
         $description = $_POST['description'] ?? '';
-        $datetime = $_POST['current_datetime'] ?? '';
-        if ($title !== '' && $description !== '' && $datetime !== '') {
+        if ($title !== '' && $description !== '') {
+            $updatedAt = date('c');
             $stmt = $db->prepare('UPDATE notes SET title = ?, description = ?, updated_at = ? WHERE id = ?');
-            $stmt->execute([$title, $description, $datetime, $id]);
+            $stmt->execute([$title, $description, $updatedAt, $id]);
             header('Location: index.php');
             exit;
         }
     }
 }
+$createdAt = new DateTime($note['created_at']);
+$createdAtDisplay = $createdAt->format('M j, Y, g:i a');
 ?>
-<!DOCTYPE html>
-<html>
-<head>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
     <title>Edit Note</title>
-    <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        document.getElementById('current_datetime').value = new Date().toISOString();
-    });
-    </script>
-</head>
-<body>
+  </head>
+  <body>
     <h1>Edit Note</h1>
-    <p>Created: <?php echo $note['created_at']; ?></p>
-    <form method="post">
-        <label>Title</label>
-        <input type="text" name="title" value="<?php echo htmlspecialchars($note['title']); ?>" required>
-        <br>
-        <label>Description</label>
-        <textarea name="description" required><?php echo htmlspecialchars($note['description']); ?></textarea>
-        <input type="hidden" name="current_datetime" id="current_datetime">
-        <br>
-        <button type="submit">Update</button>
+    <p>Created: <time datetime="<?= htmlspecialchars($note['created_at']) ?>"><?= htmlspecialchars($createdAtDisplay) ?></time></p>
+
+    <form method="post" action="/edit.php?id=<?= $id ?>">
+      <p>
+        <label for="title"><strong>Title:</strong></label><br>
+        <input id="title" name="title" type="text"
+               value="<?= htmlspecialchars($note['title']) ?>" size="40" required>
+      </p>
+
+      <p>
+        <label for="description"><strong>Description:</strong></label><br>
+        <textarea id="description" name="description"
+                  rows="6" cols="60" required><?= htmlspecialchars($note['description']) ?></textarea>
+      </p>
+
+      <p>
+        <button type="submit" name="action" value="update">Update</button>
+        <button type="submit" name="action" value="delete" onclick="return confirm('Delete this note?');">Delete</button>
+      </p>
     </form>
-    <form method="post" onsubmit="return confirm('Delete this note?');">
-        <input type="hidden" name="delete" value="1">
-        <button type="submit">Delete</button>
-    </form>
-    <a href="index.php">Back</a>
-</body>
+
+    <p><a href="/index.php">Back</a></p>
+  </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -1,23 +1,23 @@
 <?php
 require 'db.php';
 $db = get_db();
-$notes = $db->query('SELECT id, title, created_at, updated_at FROM notes ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+$notes = $db->query('SELECT id, title FROM notes ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>Noted</title>
+  <meta charset="utf-8">
+  <title>Noted</title>
 </head>
 <body>
-    <h1>Noted</h1>
-    <a href="create.php">Create Note</a>
-    <ul>
+  <h1>Noted</h1>
+
+  <p><a href="/create.php">Create Note</a></p>
+
+  <ul>
     <?php foreach ($notes as $note): ?>
-        <li>
-            <a href="edit.php?id=<?php echo $note['id']; ?>"><?php echo htmlspecialchars($note['title']); ?></a>
-            (created: <?php echo $note['created_at']; ?>, updated: <?php echo $note['updated_at']; ?>)
-        </li>
+      <li><a href="/edit.php?id=<?= $note['id']; ?>"><?= htmlspecialchars($note['title']); ?></a></li>
     <?php endforeach; ?>
-    </ul>
+  </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Format edit note timestamp with am/pm
- Rebuild create page to mirror edit layout and set timestamps server-side

## Testing
- `php -l edit.php`
- `php -l create.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad924e16f08326adbc150516402eed