### PR TITLE
Handle note creation timestamp in user's locale

### DIFF
--- a/create.php
+++ b/create.php
@@ -19,7 +19,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <title>Create Note</title>
     <script>
     document.addEventListener('DOMContentLoaded', function() {
-        document.getElementById('current_datetime').value = new Date().toISOString();
+        var now = new Date();
+        var datePart = now.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+        var timePartFull = now.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' });
+        var match = timePartFull.match(/(.*) (.*)$/);
+        var timePart = match ? match[1] : timePartFull;
+        var tzPart = match ? match[2] : '';
+        document.getElementById('current_datetime').value = datePart + ' \u2013 ' + timePart + (tzPart ? ' (' + tzPart + ')' : '');
     });
     </script>
 </head>

--- a/edit.php
+++ b/edit.php
@@ -31,8 +31,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
-$createdAt = new DateTime($note['created_at']);
-$createdAtDisplay = $createdAt->format('M j, Y, H:i');
 ?>
 <!doctype html>
 <html lang="en">
@@ -42,7 +40,7 @@ $createdAtDisplay = $createdAt->format('M j, Y, H:i');
   </head>
   <body>
     <h1>Edit Note</h1>
-    <p>Created: <time datetime="<?= htmlspecialchars($note['created_at']) ?>"><?= htmlspecialchars($createdAtDisplay) ?></time></p>
+    <p>Created: <?= htmlspecialchars($note['created_at']) ?></p>
 
     <form method="post" action="/edit.php?id=<?= $id ?>">
       <p>


### PR DESCRIPTION
## Summary
- Capture note creation time in browser locale and store formatted string
- Show saved creation timestamp directly on edit page without client-side conversion

## Testing
- `php -l create.php`
- `php -l edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad952e5d488326ac92b0002482f3e0